### PR TITLE
Calculate average score excluding outlier values

### DIFF
--- a/lib/karaokium/performances/performance.ex
+++ b/lib/karaokium/performances/performance.ex
@@ -5,6 +5,8 @@ defmodule Karaokium.Performances.Performance do
   alias Karaokium.Groups
   alias Karaokium.Repertoire
   alias Karaokium.Polling
+  alias Karaokium.Repo
+  alias Karaokium.Utils.Stats
 
   schema "performances" do
     belongs_to :karaoke, Events.Karaoke
@@ -23,5 +25,71 @@ defmodule Karaokium.Performances.Performance do
     performance
     |> cast(attrs, [:karaoke_id, :team_id, :song_id, :voting?])
     |> validate_required([:karaoke_id, :team_id, :song_id, :voting?])
+  end
+
+  @doc """
+  Calculates a performance's score.
+
+  Uses [Wikipedia's first method](https://en.wikipedia.org/wiki/Quartile#Method_1) to calculate quartile values.
+  From these, determines the outliers and excludes such values from the final average calculation.
+
+  Preloads votes if they are not already loaded.
+  Returns 0 if there are no votes.
+
+  ## Examples
+
+      iex> votes = [%Karaokium.Polling.Vote{pontuation: 1} | List.duplicate(%Karaokium.Polling.Vote{pontuation: 9}, 5)]
+      iex> performance = %Karaokium.Performances.Performance{votes: votes}
+      iex> Karaokium.Performances.Performance.score(performance)
+      #Decimal<9.00>
+
+      iex> performance = %Karaokium.Performances.Performance{votes: []}
+      iex> Karaokium.Performances.Performance.score(performance))
+      #Decimal<0>
+
+      iex> performance = %Karaokium.Performances.Performance{}
+      iex> Karaokium.Performances.Performance.score(performance))
+      #Decimal<0>
+
+  """
+  def score(%__MODULE__{votes: %Ecto.Association.NotLoaded{}} = performance) do
+    if Ecto.assoc_loaded?(performance.votes) do
+      performance
+    else
+      Repo.preload(performance, :votes)
+    end
+    |> score()
+  end
+
+  def score(%__MODULE__{votes: []}), do: Decimal.new(0)
+
+  def score(%__MODULE__{} = performance) do
+    pontuations =
+      performance.votes
+      |> Enum.map(& &1.pontuation)
+      |> Enum.sort()
+
+    q1 =
+      pontuations
+      |> Enum.take(div(length(pontuations), 2))
+      |> Stats.mean()
+
+    q3 =
+      pontuations
+      |> Enum.take(-div(length(pontuations), 2))
+      |> Stats.mean()
+
+    iqr = q3 - q1
+
+    lower = q1 - 1.5 * iqr
+    upper = q3 + 1.5 * iqr
+
+    outliers = for p <- pontuations, p < lower or p > upper, do: p
+    fixed = for p <- pontuations, p not in outliers, do: p
+
+    fixed
+    |> Stats.mean()
+    |> Decimal.from_float()
+    |> Decimal.round(2)
   end
 end

--- a/lib/karaokium/performances/performance.ex
+++ b/lib/karaokium/performances/performance.ex
@@ -53,11 +53,7 @@ defmodule Karaokium.Performances.Performance do
 
   """
   def score(%__MODULE__{votes: %Ecto.Association.NotLoaded{}} = performance) do
-    if Ecto.assoc_loaded?(performance.votes) do
-      performance
-    else
-      Repo.preload(performance, :votes)
-    end
+    Repo.preload(performance, :votes)
     |> score()
   end
 

--- a/lib/karaokium/performances/performance.ex
+++ b/lib/karaokium/performances/performance.ex
@@ -47,10 +47,6 @@ defmodule Karaokium.Performances.Performance do
       iex> Karaokium.Performances.Performance.score(performance))
       #Decimal<0>
 
-      iex> performance = %Karaokium.Performances.Performance{}
-      iex> Karaokium.Performances.Performance.score(performance))
-      #Decimal<0>
-
   """
   def score(%__MODULE__{votes: %Ecto.Association.NotLoaded{}} = performance) do
     Repo.preload(performance, :votes)

--- a/lib/karaokium/performances/performance.ex
+++ b/lib/karaokium/performances/performance.ex
@@ -61,15 +61,18 @@ defmodule Karaokium.Performances.Performance do
       |> Enum.map(& &1.pontuation)
       |> Enum.sort()
 
+    half = div(length(pontuations), 2)
+    half = if half == 0 do 1 else half end
+
     q1 =
       pontuations
-      |> Enum.take(div(length(pontuations), 2))
-      |> Stats.mean()
+      |> Enum.take(half)
+      |> Stats.median()
 
     q3 =
       pontuations
-      |> Enum.take(-div(length(pontuations), 2))
-      |> Stats.mean()
+      |> Enum.take(-half)
+      |> Stats.median()
 
     iqr = q3 - q1
 

--- a/lib/karaokium/performances/performance.ex
+++ b/lib/karaokium/performances/performance.ex
@@ -62,7 +62,13 @@ defmodule Karaokium.Performances.Performance do
       |> Enum.sort()
 
     half = div(length(pontuations), 2)
-    half = if half == 0 do 1 else half end
+
+    half =
+      if half == 0 do
+        1
+      else
+        half
+      end
 
     q1 =
       pontuations

--- a/lib/karaokium/utils/stats.ex
+++ b/lib/karaokium/utils/stats.ex
@@ -1,0 +1,18 @@
+defmodule Karaokium.Utils.Stats do
+  def mean([]), do: nil
+  def mean(list), do: Enum.sum(list) / length(list)
+
+  def median([]), do: nil
+
+  def median(list) do
+    len = length(list)
+    sorted = Enum.sort(list)
+    mid = div(len, 2)
+
+    if rem(len, 2) == 0 do
+      (Enum.at(sorted, mid - 1) + Enum.at(sorted, mid)) / 2
+    else
+      Enum.at(sorted, mid)
+    end
+  end
+end

--- a/lib/karaokium_web/live/admin/karaoke_live/show.ex
+++ b/lib/karaokium_web/live/admin/karaoke_live/show.ex
@@ -74,15 +74,7 @@ defmodule KaraokiumWeb.Admin.KaraokeLive.Show do
   end
 
   defp score(performance) do
-    if performance.votes != [] do
-      pontuations = Enum.map(performance.votes, & &1.pontuation)
-
-      (Enum.sum(pontuations) / Enum.count(pontuations))
-      |> Decimal.from_float()
-      |> Decimal.round(1)
-    else
-      0
-    end
+    Karaokium.Performances.Performance.score(performance)
   end
 
   defp qrcode(url) do

--- a/lib/karaokium_web/live/karaoke_live/show.ex
+++ b/lib/karaokium_web/live/karaoke_live/show.ex
@@ -57,15 +57,7 @@ defmodule KaraokiumWeb.KaraokeLive.Show do
   end
 
   defp score(performance) do
-    if performance.votes != [] do
-      pontuations = Enum.map(performance.votes, & &1.pontuation)
-
-      (Enum.sum(pontuations) / Enum.count(pontuations))
-      |> Decimal.from_float()
-      |> Decimal.round(1)
-    else
-      0
-    end
+    Karaokium.Performances.Performance.score(performance)
   end
 
   defp has_voted?(current_user, performance) do

--- a/test/support/fixtures/events_fixtures.ex
+++ b/test/support/fixtures/events_fixtures.ex
@@ -29,22 +29,6 @@ defmodule Karaokium.EventsFixtures do
     {:ok, karaoke} =
       attrs
       |> Enum.into(%{
-        end_date: ~D[2022-03-19],
-        name: "some name",
-        start_date: ~D[2022-03-19]
-      })
-      |> Karaokium.Events.create_karaoke()
-
-    karaoke
-  end
-
-  @doc """
-  Generate a karaoke.
-  """
-  def karaoke_fixture(attrs \\ %{}) do
-    {:ok, karaoke} =
-      attrs
-      |> Enum.into(%{
         end_date: ~N[2022-04-15 02:49:00],
         name: "some name",
         start_date: ~N[2022-04-15 02:49:00]


### PR DESCRIPTION
Resolves #8 by excluding outliers from the final score average calculation.
For this it uses [Wikipedia's first method](https://en.wikipedia.org/wiki/Quartile#Method_1) to calculate quartile values and subsequently identify the outlier values to be removed. 